### PR TITLE
Remove libgcc runtime pins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,8 @@ source:
     - 0002-revert-README-addition.patch
 
 build:
-  number: 2
+  number: 1
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
-  ignore_run_exports:
-    - libgcc-ng
-    - libstdcxx-ng
 
 requirements:
   build:
@@ -45,9 +42,6 @@ requirements:
     - dm-tree {{ dm_tree }}
     - tensorflow-base {{ tensorflow }}
     - tensorflow-estimator {{ estimator_version }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
 
 about:
   home: https://www.tensorflow.org/probability/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0002-revert-README-addition.patch
 
 build:
-  number: 1
+  number: 3
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 
 requirements:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [x] Did you write any tests to validate this change?

## Description

Adjust libgcc and libstdc++ runtime dependencies for xgboost

open-ce/open-ce#452

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
