### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins as they are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,24 +14,18 @@ source:
     - 0002-revert-README-addition.patch
 
 build:
-  number: 3
+  number: 4
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
     - bazel {{ bazel }}
   host:
     - python {{ python }}
     - tensorflow-base {{ tensorflow }}
     - tensorflow-estimator {{ estimator_version }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   run:
     - python {{ python }}
     - decorator

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # tensorflow-probability meta data file
 {% set name = "tensorflow-probability" %}
 {% set version = "0.13.0" %}
-{% set estimator_version = "2.5.0" %}
+{% set estimator_version = "2.6.0" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
